### PR TITLE
Add queue listing command

### DIFF
--- a/Commands/Combat/CombatModule.cs
+++ b/Commands/Combat/CombatModule.cs
@@ -51,4 +51,12 @@ public class CombatModule : BaseGroupModule
   [SlashCommand("tracker-setturn", "Set the current turn to a specific index.")]
   public async Task SetTurn(string gameId, int turnIndex)
     => await _turnHandler.SetTurn(Context, gameId, turnIndex);
+
+  [SlashCommand("tracker-list-queue", "List remaining combatants in the queue.")]
+  public async Task ListQueue(string gameId)
+    => await _turnHandler.ListQueue(Context, gameId);
+
+  [SlashCommand("tracker-list-order", "List all combatants for the next round.")]
+  public async Task ListOrder(string gameId)
+    => await _turnHandler.ListOrder(Context, gameId);
 }

--- a/Docs/CombatInitiativeTracker.md
+++ b/Docs/CombatInitiativeTracker.md
@@ -49,6 +49,16 @@ Sets the active turn to a specific index.
 - Errors if index is out of bounds.
 - Admin/WMs only.
 
+### `/combat tracker-list-queue <gameId>`
+Displays the remaining combatants in the current turn queue.
+
+- Useful for seeing who is left to act this round.
+
+### `/combat tracker-list-order <gameId>`
+Lists all combatants sorted by initiative. This represents the lineup that will form the next turn queue.
+
+- Helpful for checking the full roster after some combatants have been removed.
+
 ---
 
 ### `/combat tracker-reset <gameId>`


### PR DESCRIPTION
## Summary
- implement `ListQueue` handler to show remaining combatants
- expose new `/combat tracker-list-queue` slash command
- document queue listing command
- add command to list the full combatant order for the next round

## Testing
- `dotnet build --no-restore` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68658c0684e08320ab75aace99ac8de7